### PR TITLE
Use claude-opus-4-5 model for crossword clue generation

### DIFF
--- a/src/main/kotlin/com/robbiebowman/personalapi/MiniCrosswordController.kt
+++ b/src/main/kotlin/com/robbiebowman/personalapi/MiniCrosswordController.kt
@@ -182,7 +182,7 @@ class MiniCrosswordController {
     private fun generateClues(words: List<String>): PuzzleClues {
         val claudeClient = ClaudeClientBuilder()
             .withApiKey(claudeApiKey!!)
-            .withModel("claude-3-7-sonnet-latest")
+            .withModel("claude-opus-4-5")
             .withTool(::defineCrosswordClues)
             .withSystemPrompt("Given a list of words from the user, write creative and fun crossword clues for each. Avoid making overly simple or direct clues unless the word is obscure. The clues can be silly. Be sure not to sure the word itself in the clue.")
             .build()


### PR DESCRIPTION
### Motivation
- Align the Claude model identifier with the API's current name to use Opus 4.5 for crossword clue generation.
- Ensure the runtime picks the intended model by replacing the previous model identifier.

### Description
- Update `MiniCrosswordController.generateClues` to call `.withModel("claude-opus-4-5")` instead of the previous identifier.
- Preserve the existing tool registration via `.withTool(::defineCrosswordClues)` and the same system prompt.
- Add a newline at the end of the file to fix formatting.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696507361f4c832aa89a1c2885924323)